### PR TITLE
'render ssh' fixes; fixes #18 and #19

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build/
 dist/
 tmp/
 vendor/
+node_modules/
 
 *.log
 

--- a/commands/_helpers.ts
+++ b/commands/_helpers.ts
@@ -3,6 +3,7 @@ import { RuntimeConfiguration } from "../config/types/index.ts";
 import { Cliffy, Log } from '../deps.ts';
 import { getLogger, NON_INTERACTIVE } from "../util/logging.ts";
 import { APIKeyRequired, RenderCLIError } from "../errors.ts";
+import { getPaths } from "../util/paths.ts";
 
 const { Command } = Cliffy;
 
@@ -159,4 +160,40 @@ export function apiKeyOrThrow(cfg: RuntimeConfiguration): string {
 
 export function apiHost(cfg: RuntimeConfiguration) {
   return cfg.profile.apiHost ?? "api.render.com";
+}
+
+export async function apiErrorHandling<T>(logger: Log.Logger, fn: () => Promise<T>): Promise<T> {
+  try {
+    // for clarity: you almost never do `return await` but if we don't, the try-catch won't fire
+    return await fn();
+  } catch (err) {
+    const configFile = (await getPaths()).configFile;
+
+    if (err instanceof DOMException) {
+      // TODO:  can this be better?
+      //        DOMException.code is deprecated and not very useful. I assume these are relatively safe.
+      if (err.message.includes("404")) {
+          logger.error('Command received a 404 Not Found. This usually means that')
+          logger.error('no resource could be found with a given name or ID. If you')
+          logger.error('used a resource ID directly, e.g. `srv-12345678`, please check')
+          logger.error('it for correctness. If you used a resource name or slug, it\'s')
+          logger.error('likely that we couldn\'t find a resource so named.');
+      } else if (err.message.includes("401")) {
+          logger.error('Command received a 401 Unauthorized. This usually means that')
+          logger.error('you haven\'t provided credentials to the Render API or the credentials')
+          logger.error('are incorrect. Please check your API key in your config file,')
+          logger.error(`stored at '${configFile}', and refresh it or add it if need be.`)
+      } else if (err.message.includes("403")) {
+          logger.error('Command received a 403 Forbidden. This usually means that while')
+          logger.error('you have made a request with valid Render credentials, the API')
+          logger.error('doesn\'t think you have access to that resource. Check to make sure')
+          logger.error('you\'re using the right profile and that your user account is a member')
+          logger.error('of the correct team.');
+      }
+    } else {
+      logger.error("Unrecognized error: " + JSON.stringify(err, null, 2));
+    }
+
+    throw err;
+  }
 }

--- a/commands/index.ts
+++ b/commands/index.ts
@@ -8,7 +8,6 @@ import { commandsCommand } from "./commands.ts";
 import { configCommand } from "./config/index.ts";
 import { repoCommand } from './repo/index.ts';
 import { regionsCommand } from "./regions.ts";
-import { sshCommand } from "./ssh.ts";
 import { servicesCommand } from "./services/index.ts";
 
 
@@ -38,7 +37,6 @@ export const ROOT_COMMAND =
     .command("repo", repoCommand)
     .command("blueprint", blueprintCommand)
     .command("buildpack", buildpackCommand)
-    .command("ssh", sshCommand)
     .command("services", servicesCommand)
     .command("completions", new Cliffy.CompletionsCommand())
     ;

--- a/commands/services/index.ts
+++ b/commands/services/index.ts
@@ -1,4 +1,5 @@
 import { Subcommand } from "../_helpers.ts";
+import { servicesSshCommand } from "./ssh.ts";
 import { servicesTailCommand } from "./tail.ts";
 
 const desc = 
@@ -13,4 +14,5 @@ export const servicesCommand =
       Deno.exit(1);
     })
     .command("tail", servicesTailCommand)
+    .command("ssh", servicesSshCommand)
     ;

--- a/commands/services/ssh.ts
+++ b/commands/services/ssh.ts
@@ -1,26 +1,29 @@
-import { getConfig, validateRegion } from "../config/index.ts";
-import { runSSH } from "../ssh/index.ts";
-import { getLogger } from "../util/logging.ts";
-import { Subcommand } from "./_helpers.ts";
+import { getConfig, validateRegion } from "../../config/index.ts";
+import { runSSH } from "../../services/ssh/index.ts";
+import { getLogger } from "../../util/logging.ts";
+import { Subcommand } from "./../_helpers.ts";
 
 const desc = 
 `Opens a SSH session to a Render service.
 
 This command wraps your local \`ssh\` binary and passes any additional command line arguments to that binary. Before invoking \`ssh\`, \`render ssh\` ensures that your local known hosts are updated with current fingerprints for Render services, reducing the likelihood of a TOFU (trust-on-first-use) attack.`;
 
-export const sshCommand =
+export const servicesSshCommand =
   new Subcommand()
     .name('ssh')
     .description(desc)
-    .arguments("<serviceId:string> [sshArgs...:string]")
+    .arguments("[sshArgs...:string]")
     .stopEarly() // args after the service name will not be parsed, including flags
     .option("--preserve-hosts", "Do not update ~/.ssh/known_hosts with Render public keys.")
-    .action(async (opts, serviceName, ...sshArgs) => {
+    .option("--id <serviceId>", "The service ID to access via SSH.", { required: true })
+    .action(async (opts, ...sshArgs) => {
       const logger = await getLogger();
       const config = await getConfig();
 
+      const { id } = opts;
+
       const status = await runSSH({
-        serviceName, 
+        serviceId: id, 
         region: validateRegion(opts.region ?? config.profile.defaultRegion),
         sshArgs: sshArgs ?? [],
         noHosts: opts.preserveHosts ?? config.fullConfig.sshPreserveHosts ?? false,

--- a/commands/services/ssh.ts
+++ b/commands/services/ssh.ts
@@ -1,7 +1,7 @@
 import { getConfig, validateRegion } from "../../config/index.ts";
 import { runSSH } from "../../services/ssh/index.ts";
 import { getLogger } from "../../util/logging.ts";
-import { Subcommand } from "./../_helpers.ts";
+import { apiErrorHandling, Subcommand } from "./../_helpers.ts";
 
 const desc = 
 `Opens a SSH session to a Render service.

--- a/commands/services/tail.ts
+++ b/commands/services/tail.ts
@@ -17,7 +17,7 @@ export const servicesTailCommand =
     .option("--raw", "only prints the bare text of the log to stdout")
     .option("--json", "prints Render's log tail as JSON, one per message", { conflicts: ['raw'] })
     .option("--deploy-id <deployId>", "filter logs to the requested deploy ID", { collect: true })
-    .option("--service-id <serviceId>", "the service ID whose logs to request", { required: true })
+    .option("--id <serviceId>", "the service ID whose logs to request", { required: true })
     .action((opts) => withConfig(async (cfg) => {
       const logger = await getLogger();
       const apiKey = apiKeyOrThrow(cfg);
@@ -25,7 +25,7 @@ export const servicesTailCommand =
       opts.deployId = opts.deployId ?? [];
       const deployIds = opts.deployId.length > 0 ? new Set(opts.deployId ?? []) : null;
 
-      const url = `wss://${apiHost(cfg)}/v1/services/${opts.serviceId}/logs/tail`;
+      const url = `wss://${apiHost(cfg)}/v1/services/${opts.id}/logs/tail`;
       logger.debug(`tail url: ${url}, profile name: ${cfg.profileName}`);
 
       const stream = new WebSocketStream(

--- a/services/ssh/index.ts
+++ b/services/ssh/index.ts
@@ -1,5 +1,5 @@
-import { Region } from "../config/types/enums.ts";
-import { getLogger, NON_INTERACTIVE } from "../util/logging.ts";
+import { Region } from "../../config/types/enums.ts";
+import { getLogger, NON_INTERACTIVE } from "../../util/logging.ts";
 import { updateKnownHosts } from "./known-hosts.ts";
 
 const RENDER_CLI_SUBCOMMAND_ENV = {
@@ -7,7 +7,7 @@ const RENDER_CLI_SUBCOMMAND_ENV = {
 };
 
 export type RunSSHArgs = {
-  serviceName: string;
+  serviceId: string;
   region: Region;
   sshArgs: Array<string>;
   noHosts?: boolean;
@@ -21,7 +21,7 @@ export async function runSSH(args: RunSSHArgs): Promise<Deno.ProcessStatus> {
     await updateKnownHosts();
   }
 
-  const sshTarget = `${args.serviceName}@ssh.${args.region}.render.com`;
+  const sshTarget = `${args.serviceId}@ssh.${args.region}.render.com`;
 
   logger.debug(`SSH target: ${sshTarget}`);
 

--- a/services/ssh/known-hosts.ts
+++ b/services/ssh/known-hosts.ts
@@ -1,7 +1,9 @@
-import { Region } from "../config/types/enums.ts";
-import { FS } from "../deps.ts";
-import { getLogger } from "../util/logging.ts";
-import { getPaths } from "../util/paths.ts";
+import { FS } from "../../deps.ts";
+
+import { Region } from "../../config/types/enums.ts";
+import { getLogger } from "../../util/logging.ts";
+import { getPaths } from "../../util/paths.ts";
+
 
 export type SSHEndpointInfo = Readonly<{
   pubKey: string,


### PR DESCRIPTION
- `render ssh` to `render services ssh`
- `render services ssh` and `render services tail` now both take an `--id` parameter for service IDs