### PR TITLE
API refactoring; adds `render services show`; guardrails for static sites

### DIFF
--- a/api/requests.ts
+++ b/api/requests.ts
@@ -5,7 +5,6 @@ import { RuntimeConfiguration } from "../config/types/index.ts";
 import { VERSION } from "../version.ts";
 import { apiHost, apiKeyOrThrow } from "./config.ts";
 import { handleApiErrors } from "./error-handling.ts";
-import { getLogger } from "../util/logging.ts";
 
 function queryStringify(query: Record<string, any>) {
   return QueryString.stringify(query, {

--- a/commands/blueprint/index.ts
+++ b/commands/blueprint/index.ts
@@ -1,8 +1,6 @@
 import { Subcommand } from "../_helpers.ts";
 import { blueprintLaunchCommand } from "./launch.ts";
 
-import { blueprintValidateCommand } from "./validate.ts";
-
 const desc = 
 `Commands for interacting with Render Blueprints (render.yaml files).`;
 

--- a/commands/custom-domains/list.ts
+++ b/commands/custom-domains/list.ts
@@ -1,7 +1,7 @@
-import { standardAction, Subcommand } from "../_helpers.ts";
+import { apiGetAction, Subcommand } from "../_helpers.ts";
 import { getConfig } from "../../config/index.ts";
 import { getRequestJSONList } from "../../api/index.ts";
-import { getLogger, renderInteractiveOutput, renderJsonOutput } from "../../util/logging.ts";
+import { getLogger } from "../../util/logging.ts";
 
 const desc = 
 `Lists the custom domains for a given service.`;
@@ -28,11 +28,9 @@ export const customDomainsListCommand =
     .option("--verification-status <name:string[]>", "'verified' or 'unverified'", { collect: true })
     .option("--created-before <datetime>", "services created before (ISO8601)")
     .option("--created-after <datetime>", "services created after (ISO8601)")
-    .action((opts) => standardAction({
-      // TODO:  wrap this more effectively
-      //        API calls will all be basically standard, at least for GETs;
-      //        interactive/noninteractive/exit-code should be extracted and not
-      //        boilerplated.
+    .action((opts) => apiGetAction({
+      format: opts.format,
+      tableColumns: opts.columns,
       processing: async () => {
         const cfg = await getConfig();
         const logger = await getLogger();
@@ -55,11 +53,4 @@ export const customDomainsListCommand =
 
         return ret;
       },
-      interactive: (items: Array<unknown>) => {
-        renderInteractiveOutput(items, opts.format, opts.columns);
-      },
-      nonInteractive: (items: Array<unknown>) => {
-        renderJsonOutput(items);
-      },
-      exitCode: (items: Array<unknown>) => items.length > 0 ? 0 : 1,
     }));

--- a/commands/deploys/list.ts
+++ b/commands/deploys/list.ts
@@ -1,7 +1,7 @@
-import { standardAction, Subcommand } from "../_helpers.ts";
+import { apiGetAction, Subcommand } from "../_helpers.ts";
 import { getConfig } from "../../config/index.ts";
 import { getRequestJSONList } from "../../api/index.ts";
-import { getLogger, renderInteractiveOutput, renderJsonOutput } from "../../util/logging.ts";
+import { getLogger } from "../../util/logging.ts";
 
 const desc = 
 `Lists the deploys for a given service.`;
@@ -29,11 +29,9 @@ export const deploysListCommand =
     .option(
       "--end-time <timestamp:number>", "end of the time range to return"
     )
-    .action((opts) => standardAction({
-      // TODO:  wrap this more effectively
-      //        API calls will all be basically standard, at least for GETs;
-      //        interactive/noninteractive/exit-code should be extracted and not
-      //        boilerplated.
+    .action((opts) => apiGetAction({
+      format: opts.format,
+      tableColumns: opts.columns,
       processing: async () => {
         const cfg = await getConfig();
         const logger = await getLogger();
@@ -53,15 +51,7 @@ export const deploysListCommand =
 
         return ret;
       },
-      interactive: (items: Array<unknown>, logger: Log.Logger) => {
-        if (items.length > 0)  {
-          renderInteractiveOutput(items, opts.format, opts.columns);
-        } else {
-          logger.warning("No results found.");
-        }
-      },
-      nonInteractive: (items: Array<unknown>) => {
-        renderJsonOutput(items);
-      },
-      exitCode: (items: Array<unknown>) => items.length > 0 ? 0 : 1,
-    }));
+    }
+  )
+);
+  

--- a/commands/jobs/list.ts
+++ b/commands/jobs/list.ts
@@ -1,8 +1,7 @@
-import { Log } from "../../deps.ts";
-import { standardAction, Subcommand } from "../_helpers.ts";
+import { apiGetAction, Subcommand } from "../_helpers.ts";
 import { getConfig } from "../../config/index.ts";
 import { getRequestJSONList } from "../../api/index.ts";
-import { getLogger, renderInteractiveOutput, renderJsonOutput } from "../../util/logging.ts";
+import { getLogger } from "../../util/logging.ts";
 
 const desc = 
 `Lists the jobs this user can see.`;
@@ -31,11 +30,9 @@ export const jobsListCommand =
     .option("--started-after <datetime>", "jobs started after (ISO8601)")
     .option("--finished-before <datetime>", "jobs finished before (ISO8601)")
     .option("--finished-after <datetime>", "jobs finished after (ISO8601)")
-    .action((opts) => standardAction({
-      // TODO:  wrap this more effectively
-      //        API calls will all be basically standard, at least for GETs;
-      //        interactive/noninteractive/exit-code should be extracted and not
-      //        boilerplated.
+    .action((opts) => apiGetAction({
+      format: opts.format,
+      tableColumns: opts.columns,
       processing: async () => {
         const cfg = await getConfig();
         const logger = await getLogger();
@@ -60,15 +57,4 @@ export const jobsListCommand =
 
         return ret;
       },
-      interactive: (items: Array<unknown>, logger: Log.Logger) => {
-        if (items.length > 0)  {
-          renderInteractiveOutput(items, opts.format, opts.columns);
-        } else {
-          logger.warning("No results found.");
-        }
-      },
-      nonInteractive: (items: Array<unknown>) => {
-        renderJsonOutput(items);
-      },
-      exitCode: (items: Array<unknown>) => items.length > 0 ? 0 : 1,
     }));

--- a/commands/services/index.ts
+++ b/commands/services/index.ts
@@ -1,5 +1,6 @@
 import { Subcommand } from "../_helpers.ts";
 import { servicesListCommand } from "./list.ts";
+import { servicesShowCommand } from "./show.ts";
 import { servicesSshCommand } from "./ssh.ts";
 import { servicesTailCommand } from "./tail.ts";
 
@@ -14,6 +15,7 @@ export const servicesCommand =
       this.showHelp();
       Deno.exit(1);
     })
+    .command("show", servicesShowCommand)
     .command("list", servicesListCommand)
     .command("tail", servicesTailCommand)
     .command("ssh", servicesSshCommand)

--- a/commands/services/list.ts
+++ b/commands/services/list.ts
@@ -1,8 +1,7 @@
-import { Log } from "../../deps.ts";
-import { standardAction, Subcommand } from "../_helpers.ts";
+import { apiGetAction, Subcommand } from "../_helpers.ts";
 import { getConfig } from "../../config/index.ts";
 import { getRequestJSONList } from "../../api/index.ts";
-import { getLogger, renderInteractiveOutput, renderJsonOutput } from "../../util/logging.ts";
+import { getLogger } from "../../util/logging.ts";
 
 const desc = 
 `Lists the services this user can see.`;
@@ -28,16 +27,13 @@ export const servicesListCommand =
     .option("--created-after <datetime>", "services created after (ISO8601)")
     .option("--updated-before <datetime>", "services updated before (ISO8601)")
     .option("--updated-after <datetime>", "services updated after (ISO8601)")
-    .action((opts) => standardAction({
-      // TODO:  wrap this more effectively
-      //        API calls will all be basically standard, at least for GETs;
-      //        interactive/noninteractive/exit-code should be extracted and not
-      //        boilerplated.
+    .action((opts) => apiGetAction({
+      format: opts.format,
+      tableColumns: opts.columns,
       processing: async () => {
         const cfg = await getConfig();
         const logger = await getLogger();
 
-        logger.debug("dispatching getRequestJSONList");
         const ret = await getRequestJSONList(
           logger,
           cfg,
@@ -58,15 +54,6 @@ export const servicesListCommand =
 
         return ret;
       },
-      interactive: (items: Array<unknown>, logger: Log.Logger) => {
-        if (items.length > 0)  {
-          renderInteractiveOutput(items, opts.format, opts.columns);
-        } else {
-          logger.warning("No results found.");
-        }
-      },
-      nonInteractive: (items: Array<unknown>) => {
-        renderJsonOutput(items);
-      },
-      exitCode: (items: Array<unknown>) => items.length > 0 ? 0 : 1,
-    }));
+    }
+  )
+);

--- a/commands/services/show.ts
+++ b/commands/services/show.ts
@@ -1,0 +1,32 @@
+import { apiGetAction, Subcommand } from "../_helpers.ts";
+import { getConfig } from "../../config/index.ts";
+import { getRequestJSON } from "../../api/index.ts";
+import { getLogger } from "../../util/logging.ts";
+
+const desc = 
+`Fetches full details about a single service.`;
+
+export const servicesShowCommand =
+  new Subcommand()
+    .name('list')
+    .description(desc)
+    .group("Presentational controls")
+    .group("API parameters")
+    .option("--id <serviceId:string>", "the service ID (e.g. `srv-12345`)")
+    .action((opts) => apiGetAction({
+      processing: async () => {
+        const cfg = await getConfig();
+        const logger = await getLogger();
+
+        logger.debug("dispatching getRequestJSON");
+        const ret = await getRequestJSON(
+          logger,
+          cfg,
+          `/services/${opts.id}`,
+        );
+
+        return ret;
+      },
+    }
+  )
+);

--- a/commands/services/ssh.ts
+++ b/commands/services/ssh.ts
@@ -23,6 +23,7 @@ export const servicesSshCommand =
       const { id } = opts;
 
       const status = await runSSH({
+        config,
         serviceId: id, 
         region: validateRegion(opts.region ?? config.profile.defaultRegion),
         sshArgs: sshArgs ?? [],

--- a/services/constants.ts
+++ b/services/constants.ts
@@ -1,0 +1,7 @@
+export const UNLOGGABLE_SERVICE_TYPES = Object.freeze(new Set([
+  'static_site',
+]));
+
+export const UNSHELLABLE_SERVICE_TYPES = Object.freeze(new Set([
+  'static_site',
+]));

--- a/services/ssh/index.ts
+++ b/services/ssh/index.ts
@@ -1,5 +1,9 @@
+import { getRequestJSON } from "../../api/requests.ts";
 import { Region } from "../../config/types/enums.ts";
+import { RuntimeConfiguration } from "../../config/types/index.ts";
+import { RenderCLIError } from "../../errors.ts";
 import { getLogger, NON_INTERACTIVE } from "../../util/logging.ts";
+import { UNSHELLABLE_SERVICE_TYPES } from "../constants.ts";
 import { updateKnownHosts } from "./known-hosts.ts";
 
 const RENDER_CLI_SUBCOMMAND_ENV = {
@@ -7,6 +11,7 @@ const RENDER_CLI_SUBCOMMAND_ENV = {
 };
 
 export type RunSSHArgs = {
+  config: RuntimeConfiguration,
   serviceId: string;
   region: Region;
   sshArgs: Array<string>;
@@ -14,7 +19,21 @@ export type RunSSHArgs = {
 }
 
 export async function runSSH(args: RunSSHArgs): Promise<Deno.ProcessStatus> {
+  const config = args.config;
   const logger = await getLogger();
+
+  logger.debug("dispatching to check for static_site");
+  const service = (await getRequestJSON(
+    logger,
+    config,
+    `/services/${args.serviceId}`,
+  // TODO: resolve later when API clients are functional
+  // deno-lint-ignore no-explicit-any
+  )) as any;
+
+  if (UNSHELLABLE_SERVICE_TYPES.has(service.type)) {
+    throw new RenderCLIError(`Service '${args.serviceId}' is of type '${service.type}', which cannot be SSH'd into.`);
+  }
 
   logger.debug("Updating known hosts before invoking.");
   if (!args.noHosts) {

--- a/util/logging.ts
+++ b/util/logging.ts
@@ -92,8 +92,8 @@ export async function getLogger(name?: string) {
 
 export function renderInteractiveOutput(
   obj: unknown,
-  format: string,
-  tableColumns: string[],
+  tableColumns?: string[],
+  format = 'table',
 ): void {
   switch (format) {
     case 'json':
@@ -101,9 +101,13 @@ export function renderInteractiveOutput(
       return;
     case 'table':
       if (Array.isArray(obj)) {
-        // deno-lint-ignore no-explicit-any
+        if (!tableColumns) {
+          throw new Error(`Interactive output in table mode, but no table columns provided.`);
+        }
+
         const table = Cliffy.Table.from(
           obj.map(
+            // deno-lint-ignore no-explicit-any
             (o: any) => tableColumns.map(c => getAtPath(c, o)),
           ),
         );


### PR DESCRIPTION
- fixes #7 (for both log tailing and SSH)
- adds `render services show`
- DRYs up API GETs; no substitute for generated clients, but it's better!