### PR TITLE
Version command + changes for packaging

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 root = true
 
-[*.{js,ts,jsx,tsx,json,json5,yaml,yml,toml,md}]
+[*.{js,ts,jsx,tsx,json,json5,yaml,yml,toml,md,sh}]
 indent_size = 2
 tab_width = 2
 indent_style = space

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,6 @@ node_modules/
 *.log
 
 # executables
+/out
+render
 render-*

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-OUTDIR := "/tmp"
+OUTDIR ?= "/tmp"
+
+build-local:
+	./build-local.sh
 
 cache-deps:
 	deno cache --lock=deps-lock.json --lock-write --import-map=import_map.json deps.ts
@@ -7,13 +10,53 @@ deps:
 	deno cache --lock=deps-lock.json deps.ts
 
 build-linux-x86_64: deps
-	deno compile --unstable --allow-net --allow-read --allow-run --allow-write --allow-env --target=x86_64-unknown-linux-gnu --output=${OUTDIR}/render-linux-x86_64 ./entry-point.ts
+	$(eval OUTFILE ?= render-linux-x86_64)
+	deno compile \
+		--unstable \
+		--allow-net \
+		--allow-read \
+		--allow-run \
+		--allow-write \
+		--allow-env \
+		--target=x86_64-unknown-linux-gnu \
+		--output=${OUTDIR}/${OUTFILE} \
+		./entry-point.ts
 
 build-macos-x86_64: deps
-	deno compile --unstable --allow-net --allow-read --allow-run --allow-write --allow-env --target=x86_64-apple-darwin --output=${OUTDIR}/render-macos-x86_64 ./entry-point.ts
+	$(eval OUTFILE ?= render-macos-x86_64)
+	deno compile \
+		--unstable \
+		--allow-net \
+		--allow-read \
+		--allow-run \
+		--allow-write \
+		--allow-env \
+		--target=x86_64-apple-darwin \
+		--output=${OUTDIR}/${OUTFILE} \
+		./entry-point.ts
 
 build-macos-aarch64: deps
-	deno compile --unstable --allow-net --allow-read --allow-run --allow-write --allow-env --target=aarch64-apple-darwin --output=${OUTDIR}/render-macos-aarch64 ./entry-point.ts
+	$(eval OUTFILE ?= render-macos-aarch64)
+	deno compile \
+		--unstable \
+		--allow-net \
+		--allow-read \
+		--allow-run \
+		--allow-write \
+		--allow-env \
+		--target=aarch64-apple-darwin \
+		--output=${OUTDIR}/${OUTFILE} \
+		./entry-point.ts
 
 build-windows-x86_64: deps
-	deno compile --unstable --allow-net --allow-read --allow-run --allow-write --allow-env --target=x86_64-pc-windows-msvc --output=${OUTDIR}/render-windows-x86_64 ./entry-point.ts
+	$(eval OUTFILE ?= render-windows-x86_64)
+	deno compile \
+		--unstable \
+		--allow-net \
+		--allow-read \
+		--allow-run \
+		--allow-write \
+		--allow-env \
+		--target=x86_64-pc-windows-msvc \
+		--output=${OUTDIR}/${OUTFILE} \
+		./entry-point.ts

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ You can download a platform-specific build of `render-cli` from the [releases pa
 If you head to [GitHub Actions](https://github.com/render-oss/render-cli/actions) and click a passing build, you can download the latest artifacts at the bottom of the page.
 
 ### The moderately difficult way: pull the repo ###
+_This is necessary to run `render-cli` on platforms not supported by `deno compile`, such as Linux `arm64`._
+
 You can also clone this repository (fork it first, if you want!) and run the application from the repo itself. Something like this will get you sorted:
 
 ```bash
@@ -18,6 +20,9 @@ make deps
 # 'deno task run' replaces 'render' in executable invocations
 deno task run --help
 ```
+
+To build a local binary, run `make build-local`. It will emit a platform-correct binary on supported platforms and write it
+to `./out/render`.
 
 ## Using render-cli ##
 `render-cli` attempts to be a friendly and explorable command-line tool. For any command or subcommand under `render`, you can pass `--help` for detailed information on how it works.

--- a/build-local.sh
+++ b/build-local.sh
@@ -1,0 +1,62 @@
+#! /bin/sh
+# This script is a little easier than trying to do it
+# all in a Makefile. It handles Deno-specific build arguments
+# and dumps the compiled binary in `./out/render`.
+
+SCRIPT_DIR="$(dirname "$0")"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+OS_IMPL=$(uname -s)
+MACHINE=$(uname -m)
+
+dispatch_build() {
+  cd "$(dirname "$(dirname "$0")")" || exit 1
+
+  MAKE_TARGET="build-$1-$2"
+
+  [ "$DEBUG" -eq 1 ] && echo "- build-local.sh resolved to '${MAKE_TARGET}'"
+
+  export OUTDIR="$ROOT_DIR/out"
+  mkdir -p "$OUTDIR"
+  export OUTFILE="render"
+
+  [ "$DEBUG" -eq 1 ] && echo "- writing to '${OUTDIR}'/${OUTFILE}'"
+  [ -f "${OUTDIR}"/"${OUTFILE}" ] && rm "${OUTDIR}"/"${OUTFILE}"
+  make "${MAKE_TARGET}"
+}
+
+case "$OS_IMPL" in
+  "Linux")
+    case "$MACHINE" in
+      "x86_64")
+        dispatch_build "linux" "x86_64"
+      ;;
+      
+      *)
+        echo "Unsupported ${OS_IMPL} implementation: ${MACHINE}"
+        exit 1
+      ;;
+    esac
+  ;;
+  "Darwin")
+      case "$MACHINE" in
+      "x86_64")
+        dispatch_build "macos" "x86_64"
+      ;;
+
+      "arm64")
+        dispatch_build "macos" "aarch64"
+      ;;
+      
+      *)
+        echo "Unsupported ${OS_IMPL} implementation: ${MACHINE}"
+        exit 1
+      ;;
+    esac
+  ;;
+
+  *)
+    echo "Unsupported OS implementation: ${OS_IMPL}"
+    exit 1
+  ;;
+esac

--- a/commands/index.ts
+++ b/commands/index.ts
@@ -12,12 +12,12 @@ import { servicesCommand } from "./services/index.ts";
 import { deploysCommand } from "./deploys/index.ts";
 import { customDomainsCommand } from "./custom-domains/index.ts";
 import { jobsCommand } from "./jobs/index.ts";
+import { versionCommand } from './version.ts';
 
 
 export const ROOT_COMMAND =
   (new Cliffy.Command())
     .name("render")
-    .version(VERSION)
     .description("The CLI for the easiest cloud platform you'll ever use.\n\nType `render config init` to get started.")
     .globalOption(
       "-v, --verbose",
@@ -50,6 +50,7 @@ export const ROOT_COMMAND =
       this.showHelp();
       Deno.exit(1);
     })
+    .command("version", versionCommand)
     .command("commands", commandsCommand)
     .command("config", configCommand)
     .command("regions", regionsCommand)

--- a/commands/version.ts
+++ b/commands/version.ts
@@ -1,0 +1,12 @@
+import { VERSION } from "../version.ts";
+import { Subcommand } from "./_helpers.ts";
+
+const desc = `Shows the application version.`;
+
+export const versionCommand =
+  new Subcommand()
+    .name('version')
+    .description(desc)
+    .action(() => {
+      console.log(`v${VERSION}`);
+    });


### PR DESCRIPTION
- Cliffy's default `--version` is colored and less-than-readable for a computer; we want a good one for testing Homebrew postinstall, so now there's `render version` instead
- Added a `./build-local.sh` file that will attempt to do the right thing and compile a correct-arch version of the application, sending it to `./out/render` (also for Homebrew, but also for general use)
- Minor habitability improvements to builds