### PR TITLE
Referencing render-oss brew tap in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@
 ### The easy way: getting releases ###
 You can download a platform-specific build of `render-cli` from the [releases page](https://github.com/render-oss/render-cli/releases).
 
+### The easy way for OSX users: homebrew ###
+```bash
+brew tap render-oss/render
+brew install render
+```
+See [render-oss/homebrew-render](https://github.com/render-oss/homebrew-render) for more details.
+
 ### The less-easy-but-still-easy way: getting builds from `main` ###
 If you head to [GitHub Actions](https://github.com/render-oss/render-cli/actions) and click a passing build, you can download the latest artifacts at the bottom of the page.
 


### PR DESCRIPTION
Howdy! I appreciate the work on this project 👍 

I didn't see a contribution guide so I'm unsure if you're accepting community contributions, but I figured I'd add a clarification anyway since it took me a minute to find the oss-render tap.