### PR TITLE
Credential fetching via command exec

### DIFF
--- a/commands/config/add-profile.ts
+++ b/commands/config/add-profile.ts
@@ -7,12 +7,12 @@ import { getPaths } from "../../util/paths.ts";
 import { standardAction, Subcommand } from "../_helpers.ts";
 import { requestProfileInfo, writeProfile } from "./_shared.ts";
 
-const desc = 
+const desc =
 `Adds a new profile to a Render CLI config file.`;
 
 export const configAddProfileCommand =
   new Subcommand()
-    .name('init')
+    .name('add-profile')
     .description(desc)
     .option("-f, --force", "overwrites existing profile if found.")
     .arguments("<profileName:string>")

--- a/commands/config/index.ts
+++ b/commands/config/index.ts
@@ -3,6 +3,7 @@ import { configAddProfileCommand } from "./add-profile.ts";
 import { configInitCommand } from "./init.ts";
 import { configProfilesCommand } from "./profiles.ts";
 import { configSchemaCommand } from "./schema.ts";
+import { configUpgradeCommand } from "./upgrade.ts";
 
 const desc =
 `Commands for interacting with the render-cli configuration.`;
@@ -18,5 +19,6 @@ export const configCommand =
     .command("init", configInitCommand)
     .command("add-profile", configAddProfileCommand)
     .command("profiles", configProfilesCommand)
+    .command("upgrade", configUpgradeCommand)
     .command("schema", configSchemaCommand)
     ;

--- a/commands/config/upgrade.ts
+++ b/commands/config/upgrade.ts
@@ -1,0 +1,31 @@
+import { getConfig } from "../../config/index.ts";
+import { ConfigAny } from "../../config/types/index.ts";
+import { YAML } from "../../deps.ts";
+import { getLogger } from "../../util/logging.ts";
+import { getPaths } from "../../util/paths.ts";
+import { Subcommand } from "../_helpers.ts";
+
+const desc =
+`Upgrades a Render CLI config file to the latest version.`;
+
+export const configUpgradeCommand =
+  new Subcommand()
+    .name('upgrade')
+    .description(desc)
+    .action(async (opts) => {
+      const logger = await getLogger();
+      const { configFile } = await getPaths();
+      const config = await getConfig();
+
+      const currentConfig = YAML.load(await Deno.readTextFile(configFile)) as ConfigAny;
+
+      if (currentConfig.version === config.fullConfig.version) {
+        logger.info("Config is already up to date. No upgrades needed.");
+      } else {
+        logger.info(`Upgrading config from version ${currentConfig.version} to ${config.fullConfig.version}.`);
+        await Deno.copyFile(configFile, `${configFile}.${currentConfig.version}.bak`);
+        await Deno.writeTextFile(configFile, YAML.dump(config.fullConfig));
+
+        logger.info("Config upgrade complete. Thanks for using Render!");
+      }
+    });

--- a/config/types/index.ts
+++ b/config/types/index.ts
@@ -18,8 +18,12 @@ export const ProfileLatest = ProfileV2;
 
 export type UpgradeFn<T> = (cfg: T) => ConfigLatest;
 
+export type RuntimeProfile =
+  & Omit<ProfileLatest, 'apiKey'>
+  & { apiKey: string };
+
 export type RuntimeConfiguration = {
   fullConfig: ConfigLatest;
   profileName: string;
-  profile: ProfileLatest;
+  profile: RuntimeProfile;
 }

--- a/config/types/index.ts
+++ b/config/types/index.ts
@@ -1,17 +1,20 @@
 import { Type } from "../../deps.ts";
-import { ConfigV1, ProfileV1 } from './v1.ts';
+import { ConfigV1 } from './v1.ts';
+import { ConfigV2, ProfileV2 } from "./v2.ts";
 
 export type ConfigAny =
-  | ConfigV1;
+  | ConfigV1
+  | ConfigV2;
 export const ConfigAny = Type.Union([
   ConfigV1,
+  ConfigV2,
 ]);
 
-export type ConfigLatest = ConfigV1;
-export const ConfigLatest = ConfigV1;
+export type ConfigLatest = ConfigV2;
+export const ConfigLatest = ConfigV2;
 
-export type ProfileLatest = ProfileV1;
-export const ProfileLatest = ProfileV1;
+export type ProfileLatest = ProfileV2;
+export const ProfileLatest = ProfileV2;
 
 export type UpgradeFn<T> = (cfg: T) => ConfigLatest;
 

--- a/config/types/v2.ts
+++ b/config/types/v2.ts
@@ -1,0 +1,34 @@
+import {
+  Static,
+  Type
+} from '../../deps.ts';
+import { Region } from "./enums.ts";
+
+export const APIKeyV2 = Type.String({
+  pattern: 'rnd_[0-9a-zA-Z\_]+',
+  description: "Your Render API key. Will begin with 'rnd_'.",
+});
+export type APIKeyV2 = Static<typeof APIKeyV2>;
+
+export const APIKeyGetCommand = Type.Object({
+  run: Type.String({
+    description: 'A command to execute to get the API key. The command should output the API key to stdout.'
+  }),
+});
+export type APIKeyGetCommand = Static<typeof APIKeyGetCommand>;
+
+export const ProfileV2 = Type.Object({
+  apiKey: Type.Union([APIKeyV2, APIKeyGetCommand]),
+  apiHost: Type.Optional(Type.String()),
+  defaultRegion: Region,
+});
+export type ProfileV2 = Static<typeof ProfileV2>;
+
+export const ConfigV2 = Type.Object({
+  version: Type.Literal(2),
+  sshPreserveHosts: Type.Optional(Type.Boolean({
+    description: "If true, render-cli will not keep ~/.ssh/known_hosts up to date with current public keys.",
+  })),
+  profiles: Type.Record(Type.String(), ProfileV2),
+});
+export type ConfigV2 = Static<typeof ConfigV2>;

--- a/config/types/v2.ts
+++ b/config/types/v2.ts
@@ -11,7 +11,7 @@ export const APIKeyV2 = Type.String({
 export type APIKeyV2 = Static<typeof APIKeyV2>;
 
 export const APIKeyGetCommand = Type.Object({
-  run: Type.String({
+  run: Type.Array(Type.String(), {
     description: 'A command to execute to get the API key. The command should output the API key to stdout.'
   }),
 });


### PR DESCRIPTION
- adds the ability to run a command in order to fetch a secret from a store. For example, you can use 1Password or the macOS keychain to store your credentials now, independently from our config.yaml file, to avoid unencrypted secrets at rest.
- Upgrades config file to version 2
- Includes automatic upgrading to version 2
- adds `render config upgrade` to permanently upgrade a config file to the latest version (saves backup)