### PR TITLE
add delete service subcommand

### DIFF
--- a/api/requests.ts
+++ b/api/requests.ts
@@ -12,13 +12,43 @@ function queryStringify(query: Record<string, any>) {
   });
 }
 
+type httpMethod =
+  | "GET"
+  | "HEAD"
+  | "POST"
+  | "PUT"
+  | "DELETE"
+  | "CONNECT"
+  | "OPTIONS"
+  | "TRACE"
+  | "PATCH";
+
 let apiReqCount = 0;
 
 export function getRequestRaw(
   logger: Log.Logger,
   cfg: RuntimeConfiguration,
   path: string,
+  query: Record<string, any> = {}
+): Promise<Response> {
+  return requestRaw(logger, cfg, path, query, "GET");
+}
+
+export function deleteRequestRaw(
+  logger: Log.Logger,
+  cfg: RuntimeConfiguration,
+  path: string,
+  query: Record<string, any> = {}
+): Promise<Response> {
+  return requestRaw(logger, cfg, path, query, "DELETE");
+}
+
+function requestRaw(
+  logger: Log.Logger,
+  cfg: RuntimeConfiguration,
+  path: string,
   query: Record<string, any> = {},
+  method: httpMethod = "GET"
 ): Promise<Response> {
   return handleApiErrors(logger, async () => {
     const reqNumber = apiReqCount++;

--- a/api/requests.ts
+++ b/api/requests.ts
@@ -60,7 +60,7 @@ function requestRaw(
 
     const url = `https://${apiHost(cfg)}/v1${path}?${queryStringify(query)}`;
 
-    logger.debug(`api dispatch: ${reqNumber}: url ${url} (query: ${JSON.stringify(query)})`);
+    logger.debug(`api dispatch: ${reqNumber}: method: ${method} url ${url} (query: ${JSON.stringify(query)})`);
 
     const response = await fetch(url, {
       headers: {
@@ -68,6 +68,7 @@ function requestRaw(
         'user-agent': `Render CLI/${VERSION}`,
         accept: 'application/json',
       },
+      method: method,
     });
     if (!response.ok) {
       // this kind of has to be a DOMException because it encapsulates the notion of NetworkError

--- a/commands/services/delete.ts
+++ b/commands/services/delete.ts
@@ -1,0 +1,25 @@
+import { apiGetAction, Subcommand } from "../_helpers.ts";
+import { getConfig } from "../../config/index.ts";
+import { deleteRequestRaw } from "../../api/index.ts";
+import { getLogger } from "../../util/logging.ts";
+
+const desc = `Deletes a service`;
+
+export const servicesDeleteCommand = new Subcommand()
+  .name("list")
+  .description(desc)
+  .group("API parameters")
+  .option("--id <serviceId:string>", "the service ID (e.g. `srv-12345`)")
+  .action((opts) =>
+    apiGetAction({
+      processing: async () => {
+        const cfg = await getConfig();
+        const logger = await getLogger();
+
+        const ret = await deleteRequestRaw(logger, cfg, `/services/${opts.id}`);
+        logger.debug(`deleted service ${opts.id}`);
+
+        return ret;
+      },
+    })
+  );

--- a/commands/services/delete.ts
+++ b/commands/services/delete.ts
@@ -1,4 +1,4 @@
-import { apiGetAction, Subcommand } from "../_helpers.ts";
+import { standardAction, Subcommand } from "../_helpers.ts";
 import { getConfig } from "../../config/index.ts";
 import { deleteRequestRaw } from "../../api/index.ts";
 import { getLogger } from "../../util/logging.ts";
@@ -11,13 +11,15 @@ export const servicesDeleteCommand = new Subcommand()
   .group("API parameters")
   .option("--id <serviceId:string>", "the service ID (e.g. `srv-12345`)")
   .action((opts) =>
-    apiGetAction({
+    standardAction({
+      exitCode: (res) => (res?.status == 204 ? 0 : 1),
+      interactive: () => undefined,
       processing: async () => {
         const cfg = await getConfig();
         const logger = await getLogger();
 
         const ret = await deleteRequestRaw(logger, cfg, `/services/${opts.id}`);
-        logger.debug(`deleted service ${opts.id}`);
+        logger.debug(`deleted service ${opts.id}: ${ret.status}`);
 
         return ret;
       },

--- a/commands/services/index.ts
+++ b/commands/services/index.ts
@@ -3,6 +3,7 @@ import { servicesListCommand } from "./list.ts";
 import { servicesShowCommand } from "./show.ts";
 import { servicesSshCommand } from "./ssh.ts";
 import { servicesTailCommand } from "./tail.ts";
+import { servicesDeleteCommand } from "./delete.ts";
 
 const desc = 
 `Commands for observing and managing Render services.`;
@@ -16,6 +17,7 @@ export const servicesCommand =
       Deno.exit(1);
     })
     .command("show", servicesShowCommand)
+    .command("delete", servicesDeleteCommand)
     .command("list", servicesListCommand)
     .command("tail", servicesTailCommand)
     .command("ssh", servicesSshCommand)


### PR DESCRIPTION
Adds support for deleting a service. Here's an example of it in action:

```
$ ./bin/render services list
id                       name                type        serviceDetails.env slug                serviceDetails.numInstances
crn-cj5s2dicn0vc73fv4rlh test-service-delete cron_job    image              test-service-delete                            
srv-cisrtch5rnujejodpfq1 metrics-test-stage  web_service image              metrics-test-stage  1                          
srv-cisrtch5rnujejodpfqh metrics-test-prod   web_service image              metrics-test-prod   1                          
srv-chnpupo2qv207f2k374h readme-next         web_service docker             readme-next         1                          

$ ./bin/render services delete --id crn-cj5s2dicn0vc73fv4rlh

$ ./bin/render services list
id                       name               type        serviceDetails.env slug               serviceDetails.numInstances
srv-cisrtch5rnujejodpfq1 metrics-test-stage web_service image              metrics-test-stage 1                          
srv-cisrtch5rnujejodpfqh metrics-test-prod  web_service image              metrics-test-prod  1                          
srv-chnpupo2qv207f2k374h readme-next        web_service docker             readme-next        1
```

- It doesn't look like any of the other commands are tested, so there are no tests
- I couldn't figure out what formatter you are using so the code may not be formatted according to your project's style
  - I'm happy to fix that if you can help me out
