### PR TITLE
use stream.opened instead of stream.connection

### DIFF
--- a/commands/services/tail.ts
+++ b/commands/services/tail.ts
@@ -59,7 +59,11 @@ export const servicesTailCommand =
         let writer: WritableStreamDefaultWriter<string | Uint8Array>;
   
         try {
-          conn = await stream.connection;
+          if(stream.connection) {
+            conn = await stream.connection;
+          } else {
+            conn = await stream.opened;
+          }
           reader = await conn.readable.getReader();
           writer = await conn.writable.getWriter();
         } catch (err) {

--- a/commands/services/tail.ts
+++ b/commands/services/tail.ts
@@ -59,11 +59,7 @@ export const servicesTailCommand =
         let writer: WritableStreamDefaultWriter<string | Uint8Array>;
   
         try {
-          if (stream.connection) {
-            conn = await stream.connection;
-          } else {
-            conn = await stream.opened;
-          }
+          conn = await stream.opened;
           reader = await conn.readable.getReader();
           writer = await conn.writable.getWriter();
         } catch (err) {

--- a/commands/services/tail.ts
+++ b/commands/services/tail.ts
@@ -59,7 +59,7 @@ export const servicesTailCommand =
         let writer: WritableStreamDefaultWriter<string | Uint8Array>;
   
         try {
-          if(stream.connection) {
+          if (stream.connection) {
             conn = await stream.connection;
           } else {
             conn = await stream.opened;

--- a/util/find-up.test.ts
+++ b/util/find-up.test.ts
@@ -51,5 +51,5 @@ Deno.test('findUp', async (t) => {
     assertEquals(ret, null);
   });
 
-  Deno.remove(root, { recursive: true });
+  await Deno.remove(root, { recursive: true });
 });


### PR DESCRIPTION
Deno [changed](https://github.com/denoland/deno/pull/20878) the `WebSocketStream` API to rename the `connection` property to `opened`. This proposed change would add a quick check to see which version of the API is in use and use the appropriate property. This should fix https://github.com/render-oss/homebrew-render/issues/12

- Tested using Deno 1.37.2 by running `deno task run services tail --id XXXXXXX` to ensure that tails works as expected with the check