### PR TITLE
Use GFM alert style for deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # render-cli (deprecated) #
 
-**This CLI is deprecated and no longer under active development. We recommend using our newer [actively-maintained CLI](https://github.com/render-oss/render-cli-alpha) instead.**
+> [!WARNING]  
+> **This CLI is deprecated and no longer under active development. We recommend using our newer [actively-maintained CLI](https://github.com/render-oss/render-cli-alpha) instead.**
 
 ## Getting render-cli ##
 ### The easy way: getting releases ###


### PR DESCRIPTION
Use the alert style to make the deprecation notice more prominent.

<img width="906" alt="Screenshot 2024-11-11 at 2 11 44 PM" src="https://github.com/user-attachments/assets/69b05bd0-8939-4bb3-9631-466ac5dd09c5">
